### PR TITLE
chore: enforce minimum dependency age

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "main": "update-patrons.mjs",
   "type": "module",
+  "packageManager": "pnpm@11.15.1",
   "scripts": {
     "build": "ncc build update-patrons.mjs -o dist"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   '@evilmartians/lefthook': true
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Age gate

Enforces a seven-day minimum release age for pnpm dependencies.

## Metadata edits

- Pins the package manager to `pnpm@11.15.1` in `package.json`.
- Adds `minimumReleaseAge: 10080` to `pnpm-workspace.yaml`.

## Verification

- Inspected the Git status and staged diff.
- Ran `git diff --check` and `git diff --staged --check` only.
- Did not run package-manager, test, lint, format, build, or validation commands.